### PR TITLE
Add response classes for entities

### DIFF
--- a/src/main/java/com/couse/security/application/api/response/BusRouteResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/BusRouteResponse.java
@@ -1,0 +1,17 @@
+package com.couse.security.application.api.response;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record BusRouteResponse(
+    UUID busRouteUuid,
+    BusServicePointResponse departureServicePoint,
+    BusServicePointResponse arrivalServicePoint,
+    String busRouteCode,
+    String busRouteName,
+    String busRouteDescription,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt,
+    boolean active
+) {
+}

--- a/src/main/java/com/couse/security/application/api/response/BusRouteScheduleResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/BusRouteScheduleResponse.java
@@ -1,0 +1,21 @@
+package com.couse.security.application.api.response;
+
+import com.couse.security.application.entity.BusRouteSchedule.BusClass;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record BusRouteScheduleResponse(
+    UUID busRouteScheduleUuid,
+    BusRouteResponse busRoute,
+    String busRouteScheduleCode,
+    String busRouteScheduleName,
+    BusClass busClass,
+    int capacity,
+    OffsetDateTime departureTime,
+    OffsetDateTime arrivalTime,
+    int capacityAvailable,
+    boolean isCapacityAvailable,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/couse/security/application/api/response/BusServicePointResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/BusServicePointResponse.java
@@ -1,0 +1,14 @@
+package com.couse.security.application.api.response;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record BusServicePointResponse(
+    UUID servicePointUuid,
+    String servicePointName,
+    String servicePointAddress,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt,
+    boolean active
+) {
+}

--- a/src/main/java/com/couse/security/application/api/response/BusTicketPassengerResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/BusTicketPassengerResponse.java
@@ -1,0 +1,13 @@
+package com.couse.security.application.api.response;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record BusTicketPassengerResponse(
+    UUID busTicketPassengerUuid,
+    String passengerName,
+    String passengerDocument,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/couse/security/application/api/response/BusTicketResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/BusTicketResponse.java
@@ -1,0 +1,22 @@
+package com.couse.security.application.api.response;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.couse.security.application.api.response.BusTicketPassengerResponse;
+
+public record BusTicketResponse(
+    UUID busTicketUuid,
+    BusRouteScheduleResponse busRouteSchedule,
+    List<BusTicketPassengerResponse> passengers, // This will require BusTicketPassengerResponse
+    boolean canceled,
+    String ticketNumber,
+    OffsetDateTime issuedAt,
+    boolean paid,
+    boolean refunded,
+    UUID customerUuid,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/couse/security/application/api/response/CustomerResponse.java
+++ b/src/main/java/com/couse/security/application/api/response/CustomerResponse.java
@@ -1,0 +1,14 @@
+package com.couse.security.application.api.response;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CustomerResponse(
+    UUID customerUUID,
+    String customerName,
+    String email,
+    String phoneNumber,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+}


### PR DESCRIPTION
This commit introduces new response classes under `src/main/java/com/couse/security/application/api/response/` for the following entities:

- BusRoute
- BusRouteSchedule
- BusServicePoint
- BusTicket
- BusTicketPassenger
- Customer

These response classes will be used for API responses and include relevant fields from their corresponding entities, omitting metadata fields like `createdBy`, `updatedBy`, `deleted`, and `deletedAt`.